### PR TITLE
#158758704 update ui for add and edit event to have start date and end date

### DIFF
--- a/client/src/components/Center/CenterInfo.js
+++ b/client/src/components/Center/CenterInfo.js
@@ -133,16 +133,16 @@ class CenterInfo extends Component {
             </ul>
             <br />
             <h5><strong>Events</strong></h5>
-            {set && set.events && set.events.map(eve =>
+            {set && set.events && set.events.map(eventDate =>
                   (<div
                     key={Math.floor(Math.random() * 10906) + 30}
                     className="card d-lg-inline-block"
                     style={{ width: '15rem' }}
                   >
                     <div className="card-body">
-                      <p className="card-text">
-                        {eve.eventdate}
-                      </p>
+                      <h6 className="card-text">
+                        {eventDate.startDate} To {eventDate.endDate}
+                      </h6>
                     </div>
                    </div>
                 ))}
@@ -188,7 +188,8 @@ CenterInfo.propTypes = {
   loadedCenter: PropTypes.shape({
     id: PropTypes.number,
     eventName: PropTypes.string,
-    eventdate: PropTypes.string,
+    startDate: PropTypes.string,
+    endDate: PropTypes.string,
     time: PropTypes.string,
     purpose: PropTypes.string,
   }),

--- a/client/src/components/Event/Addevent.js
+++ b/client/src/components/Event/Addevent.js
@@ -13,7 +13,8 @@ import * as action from '../../store/actions/index';
 class AddEvent extends Component {
    state = {
      name: '',
-     date: '',
+     startDate: '',
+     endDate: '',
      time: '',
      purpose: '',
      center: '',
@@ -56,8 +57,12 @@ class AddEvent extends Component {
       toast.error('Event Name cannot be blank');
     } else if (reWhiteSpace.test(this.state.fullname) === true) {
       toast.error('Event Name cannot white space');
-    } else if (this.state.date === '') {
-      toast.error('Event Date cannot be blank');
+    } else if (this.state.startDate === '') {
+      toast.error('Event start date cannot be blank');
+    } else if (this.state.endDate === '') {
+      toast.error('Event end date cannot be blank');
+    } else if (this.state.endDate < this.state.startDate) {
+      toast.error('!Event end date cannot be behind event start date');
     } else if (this.state.time === '') {
       toast.error('Event Time cannot be blank');
     } else if (this.state.purpose === '') {
@@ -151,7 +156,8 @@ class AddEvent extends Component {
             onChange={this.onChange}
             onSubmit={this.onSubmit}
             name={this.state.name}
-            date={this.state.date}
+            startDate={this.state.startDate}
+            endDate={this.state.endDate}
             time={this.state.time}
             purpose={this.state.purpose}
             getCenter={this.getCenter}

--- a/client/src/components/Event/EditEvent.js
+++ b/client/src/components/Event/EditEvent.js
@@ -13,7 +13,8 @@ import * as action from '../../store/actions/index';
 class EditEvent extends Component {
    state = {
      name: this.props.loadedEvent.eventName,
-     date: this.props.loadedEvent.eventdate,
+     startDate: this.props.loadedEvent.startDate,
+     endDate: this.props.loadedEvent.endDate,
      time: this.props.loadedEvent.time,
      purpose: this.props.loadedEvent.purpose,
      center: this.props.loadedEvent.centerId,
@@ -66,8 +67,12 @@ class EditEvent extends Component {
        toast.error('Event Name cannot be blank');
      } else if (reWhiteSpace.test(this.state.fullname) === true) {
        toast.error('Event Name cannot white space');
-     } else if (this.state.date === '') {
-       toast.error('Event Date cannot be blank');
+     } else if (this.state.startDate === '') {
+       toast.error('Event start date cannot be blank');
+     } else if (this.state.endDate === '') {
+       toast.error('Event end date cannot be blank');
+     } else if (this.state.endDate < this.state.startDate) {
+       toast.error('!Event end date cannot be behind event start date');
      } else if (this.state.time === '') {
        toast.error('Event Time cannot be blank');
      } else if (this.state.purpose === '') {
@@ -158,7 +163,8 @@ class EditEvent extends Component {
             onChange={this.onChange}
             onSubmit={this.onSubmit}
             name={this.state.name}
-            date={this.state.date}
+            startDate={this.state.startDate}
+            endDate={this.state.endDate}
             time={this.state.time}
             purpose={this.state.purpose}
             getCenter={this.getCenter}
@@ -183,7 +189,8 @@ EditEvent.propTypes = {
   initEditEvent: PropTypes.func.isRequired,
   loadedEvent: PropTypes.shape({
     eventName: PropTypes.string,
-    eventdate: PropTypes.string,
+    startDate: PropTypes.string,
+    endDate: PropTypes.endDate,
     purpose: PropTypes.string,
     time: PropTypes.string,
     userId: PropTypes.number,

--- a/client/src/components/Event/EventInfo.js
+++ b/client/src/components/Event/EventInfo.js
@@ -50,7 +50,8 @@ class EventInfo extends Component {
   render() {
     const {
       eventName,
-      eventdate,
+      startDate,
+      endDate,
       time,
       purpose,
     } = this.props.events;
@@ -151,8 +152,11 @@ class EventInfo extends Component {
                 <h5 ><strong>Event Name</strong></h5>
                 <h6 className="list-group-item">{eventName}</h6>
                 <br />
-                <h5><strong>Date</strong></h5>
-                <h6 className="list-group-item">{eventdate}</h6>
+                <h5><strong>Start Date</strong></h5>
+                <h6 className="list-group-item">{startDate}</h6>
+                <br />
+                <h5><strong>End Date</strong></h5>
+                <h6 className="list-group-item">{endDate}</h6>
                 <br />
                 <h5><strong>Time</strong></h5>
                 <h6 className="list-group-item">{time}</h6>

--- a/client/src/components/Event/Form/EventForm.js
+++ b/client/src/components/Event/Form/EventForm.js
@@ -25,12 +25,23 @@ const eventForm = props => (
         </div>
 
         <div className="form-group col-md-6">
-          <h5><label htmlFor="inputPassword4">Date</label></h5>
+          <h5><label htmlFor="inputPassword4">Start Date</label></h5>
           <input
             type="date"
-            value={props.date}
+            value={props.startDate}
             onChange={props.onChange}
-            name="date"
+            name="startDate"
+            className="form-control form-control-lg"
+          />
+        </div>
+
+        <div className="form-group col-md-6">
+          <h5><label htmlFor="inputPassword4">End Date</label></h5>
+          <input
+            type="date"
+            value={props.endDate}
+            onChange={props.onChange}
+            name="endDate"
             className="form-control form-control-lg"
           />
         </div>
@@ -122,7 +133,8 @@ eventForm.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
-  date: PropTypes.string.isRequired,
+  startDate: PropTypes.string.isRequired,
+  endDate: PropTypes.string.isRequired,
   time: PropTypes.string.isRequired,
   showCenterNane: PropTypes.object.isRequired,
   numberOfPages: PropTypes.object.isRequired,

--- a/client/src/components/Event/ViewEvents.js
+++ b/client/src/components/Event/ViewEvents.js
@@ -68,7 +68,6 @@ class ViewEvent extends Component {
    *
    * @returns {JSX} JSX representation of component
    */
-    console.log(this.props.events);
     return (
       <div>
         <div className="center thebody" >

--- a/client/src/components/Route/Route.js
+++ b/client/src/components/Route/Route.js
@@ -48,7 +48,7 @@ const routers = () => (
     <Route
       path="/events/:id"
       exact
-      component={EventInfo}
+      component={RequireAuth(EventInfo)}
     />
     <Route
       path="/events/edit/:id"

--- a/client/src/components/UI/Loading.js
+++ b/client/src/components/UI/Loading.js
@@ -4,7 +4,7 @@ const Loading = () => (
   <div className="container" style={{ paddingTop: '100px' }}>
     <div className="loader" />
     <p className="center-item shadow">
-      Unable to connect Reaource Not Found or invalid Url.
+      Unable to connect Resource Not Found or invalid Url.
         Refresh your browser or check your internet connection
     </p>
     <div className="container" style={{ paddingTop: '200px' }} />

--- a/server/controllers/centerController.js
+++ b/server/controllers/centerController.js
@@ -62,8 +62,7 @@ class Centers {
         {
           model: Event,
           as: 'events',
-          attributes: ['eventdate']
-
+          attributes: ['startDate', 'endDate']
         }
       ],
     })

--- a/server/middleware/validator.js
+++ b/server/middleware/validator.js
@@ -344,6 +344,15 @@ class Validate {
             endDate: {
               $between: [startDate, endDate]
             }
+          },
+          {
+            startDate: {
+              $lte: startDate
+            }
+          }, {
+            endDate: {
+              $gte: endDate
+            }
           }
         ]
       }


### PR DESCRIPTION
#### What does this PR do?
adds a start and end date field to the add event and edit event page

#### Description of Task to be completed?
when a user wants to add a new event or edit an existing event. They should see a field to add a start date for the even and an end date for the event

#### How should this be manually tested?
on the add event page, a field for start date and end date should be available

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories? (If applicable)
#158758704]

#### Screenshots (If applicable)
None